### PR TITLE
Updates use of vpc-vsi module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -26,7 +26,7 @@ data "ibm_is_image" "ubuntu_image" {
 }
 
 module "scc_vsi" {
-  source = "github.com/cloud-native-toolkit/terraform-ibm-vpc-vsi.git?ref=v1.2.2"
+  source = "github.com/cloud-native-toolkit/terraform-ibm-vpc-vsi.git?ref=v1.3.1"
 
   resource_group_id = var.resource_group_id
   region            = var.region

--- a/module.yaml
+++ b/module.yaml
@@ -24,6 +24,16 @@ versions:
       refs:
         - source: github.com/cloud-native-toolkit/terraform-ibm-vpc-ssh
           version: ">= 1.0.0"
+    - id: cos_bucket
+      refs:
+        - source: github.com/cloud-native-toolkit/terraform-ibm-object-storage-bucket
+          version: ">= 0.0.1"
+      optional: true
+    - id: kms_key
+      refs:
+        - source: github.com/cloud-native-toolkit/terraform-ibm-kms-key
+          version: ">= 0.0.1"
+      optional: true
   variables:
     - name: resource_group_id
       moduleRef:
@@ -53,5 +63,13 @@ versions:
       moduleRef:
         id: vpcssh
         output: private_key
-    - name: scc_registration_key
-      scope: global
+    - name: flow_log_cos_bucket_name
+      moduleRef:
+        id: cos_bucket
+        output: bucket_name
+      optional: true
+    - name: kms_key_crn
+      moduleRef:
+        id: kms_key
+        output: crn
+      optional: true


### PR DESCRIPTION
- Bumps ibm-vpc-vsi to v1.3.1
- Adds cos_bucket and kms_key to module dependencies

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>