### PR TITLE
Adds rules to network ACL for subnet to allow req traffic

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -87,3 +87,17 @@ module "scc_vsi" {
   ]
   base_security_group = var.base_security_group
 }
+
+data ibm_is_subnet subnet {
+  count = var.vpc_subnet_count > 0 ? 1 : 0
+
+  identifier = var.vpc_subnets[0].id
+}
+
+resource null_resource open_acl_rules {
+  count = var.vpc_subnet_count > 0 ? 1 : 0
+
+  provisioner "local-exec" {
+    command = "${path.module}/scripts/open-acl-rules.sh ${data.ibm_is_subnet.subnet[0].network_acl}"
+  }
+}

--- a/scripts/open-acl-rules.sh
+++ b/scripts/open-acl-rules.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+NETWORK_ACL="$1"
+
+## TODO more sophisiticated logic needed to 1) test for existing rules and 2) place this rule in the right order
+
+ibmcloud is network-acl-rule-add "${NETWORK_ACL}" allow inbound all "0.0.0.0/0" "0.0.0.0/0" --name allow-all-ingress
+ibmcloud is network-acl-rule-add "${NETWORK_ACL}" allow outbound all "0.0.0.0/0" "0.0.0.0/0" --name allow-all-egress


### PR DESCRIPTION
- Adds rules to allow all inbound and outbound traffic from the internet (as required by collector)

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>